### PR TITLE
Flake.nix

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -3,6 +3,7 @@
   pypiDataRev ? (builtins.fromJSON (builtins.readFile ./mach_nix/nix/PYPI_DEPS_DB.json)).rev,
   pypiDataSha256 ? (builtins.fromJSON (builtins.readFile ./mach_nix/nix/PYPI_DEPS_DB.json)).sha256,
   python ? "python3",
+  flattenTree,
   ...
 }:
 
@@ -49,9 +50,7 @@ let
     else
       (import ./mach_nix/nix/mkPython.nix { inherit pkgs pypiDataRev pypiDataSha256; })
         python (l.throwOnDeprecatedArgs caller args);
-
-in
-rec {
+  originalDefault = rec {
   # the mach-nix cmdline tool derivation
   mach-nix = python_machnix.pkgs.buildPythonPackage rec {
     pname = "mach-nix";
@@ -96,4 +95,12 @@ rec {
 
   # this might beuseful for someone
   inherit (l) mergeOverrides;
+};
+in flattenTree {
+  mkPython = originalDefault.mkPython;
+  mach-nix = originalDefault.mach-nix;
+  "with" = originalDefault.pythonWith;
+  pythonWith = originalDefault.pythonWith;
+  shellWith = originalDefault.shellWith;
+  dockerImageWith = originalDefault.dockerImageWith;
 }

--- a/flake.lock
+++ b/flake.lock
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1601171649,
-        "narHash": "sha256-G3RUAi2DUq6r3ntASLS+LZC/Eamot55W1+xmBOgEh3M=",
+        "lastModified": 1602891742,
+        "narHash": "sha256-rsDcBC0ceCw9c9d+W8tdc0hXHZZLCj7eRAO4whRMMeQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "84d74ae9c9cbed73274b8e4e00be14688ffc93fe",
+        "rev": "8133b9cb5f7c00d4fe31c8c2c4b525bc2650bfc0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,13 +10,16 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
-        mach-nix-default = import ./default.nix {inherit pkgs;};
+        mach-nix-default = import ./default.nix {
+          inherit pkgs;
+          flattenTree = flake-utils.lib.flattenTree;
+        };
       in rec
       {
         devShell = import ./shell.nix {
           inherit pkgs;
         };
-        packages = flake-utils.lib.flattenTree {
+        packages = {
           mach-nix = mach-nix-default.mach-nix;
           "with" = mach-nix-default.pythonWith;
           pythonWith = mach-nix-default.pythonWith;


### PR DESCRIPTION
`flake.nix` seems to be outdated

- seemingly unneeded ${system}s sprinkled around (already taken care by flake-utils)?
- old `flake.lock` seems to cause cache-misses (or maybe I'm doing smth wrong)
- `nix show` fails trying to evaluate non-native `system`'s attributes